### PR TITLE
change the dockerfile to use ubi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.8-slim-buster
-
-WORKDIR /app
-
-COPY requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
-
-COPY . .
+FROM registry.access.redhat.com/ubi8/ubi
+RUN yum -y install python3 && pip3 install label-studio
 
 CMD [ "label-studio", "start"]
-


### PR DESCRIPTION
this change makes things a little lighter by using a ubi image for the base and then just installing label-studio directly. if the requirements are needed for extra packages it should be easy to add it back in.